### PR TITLE
make the notifications for passing CI get sent only on change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ notifications:
         recipients:
             - sjsrey@gmail.com
             - levi.john.wolf@gmail.com
-        on_success: always
+        on_success: change 
         on_failure: always
 
 after_success:


### PR DESCRIPTION
this'll help with overzealous status reporting. 
